### PR TITLE
Preventing a ship without a Facility set from using the SPH defaults.

### DIFF
--- a/AutoAction/AutoActionFlight.cs
+++ b/AutoAction/AutoActionFlight.cs
@@ -136,10 +136,9 @@ namespace AutoAction
 
 		static FacilitySettings GetFacilitySettings()
 		{
-			var settings = new Settings();
+			Settings settings = new Settings();
 			settings.Load();
-			var isVab = ShipConstruction.ShipType == EditorFacility.VAB;
-			return isVab ? settings.VabSettings : settings.SphSettings;
+			return settings.For(ShipConstruction.ShipType);
 		}
 
 		static readonly IDictionary<int, KSPActionGroup> KspActions = new Dictionary<int, KSPActionGroup>

--- a/AutoAction/Settings.cs
+++ b/AutoAction/Settings.cs
@@ -45,5 +45,15 @@ namespace AutoAction
 
 		static readonly Vector2 DefaultWindowPosition = new Vector2(431, 25);
 		static readonly string SettingsFilePath = $"GameData/{nameof(AutoAction)}/Plugins/PluginData/{nameof(AutoAction)}.settings";
+
+		internal FacilitySettings For(EditorFacility shipType)
+		{
+			switch (shipType)
+			{
+				case EditorFacility.SPH: return this.SphSettings;
+				case EditorFacility.VAB: return this.VabSettings;
+				default: return new FacilitySettings();
+			}
+		}
 	}
 }


### PR DESCRIPTION
Hi! (again)

I found this weird situation on some vessels of mine (most of them imported from older KSPs): my rockets were being staged and fired even by the VAB defaults and the vessel's settings set to **do not** stage.

I took me some days until I noticed that I was using Stage on the SPH defaults. By editing the file and disabling the Stage, my rockets stopped being staged on the launch pad.

Checking the code, I found the problem - you was checking for the VAB, and assuming SPH if not. I solved the problem by specifically checking for SPH and VAB, and by shoving a new empty Settings if something else appeared somehow.

I don't have the slightest idea if this can happen on 1.12.x (I still playing on older ones, my savegames could not be imported on the new KSPs after 1.8) however.

Cheers!